### PR TITLE
Update sdl2 crate version to 0.34.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdl2-unifont"
-version = "1.0.1"
+version = "1.0.2"
 
 authors = ["Carl Albrecht <invlpg@protonmail.com>"]
 license = "GPL-3.0-or-later"
@@ -25,9 +25,9 @@ plane-0 = []
 plane-1 = []
 
 [dependencies]
-sdl2 = "0.31.0"
 rust-lzma = "0.3.0"
 bit_field = "0.9.0"
+sdl2 = "0.34.4"
 
 [build-dependencies]
 rust-lzma = "0.3.0"


### PR DESCRIPTION
While trying to use this crate in my game engine, I ran into this error:

```
error: multiple packages link to native library `SDL2`, but a native library can be linked only once

package `sdl2-sys v0.31.0`
    ... which is depended on by `sdl2 v0.31.0`
    ... which is depended on by `sdl2-unifont v1.0.1`
    ... which is depended on by `simple-game-engine v0.7.0 (/Users/mikey/code/simple-game-engine-rs)`
links to native library `SDL2`

package `sdl2-sys v0.34.4`
    ... which is depended on by `sdl2 v0.34.4`
    ... which is depended on by `simple-game-engine v0.7.0 (/Users/mikey/code/simple-game-engine-rs)`
also links to native library `SDL2`
```

All that was required to fix this was to change the sdl2 version in `Cargo.toml`. The sdl2 API hasn't changed, at least the subset that this crate uses, so everything still compiles and works fine.